### PR TITLE
Fix variant name for Artillery_Ruby board

### DIFF
--- a/buildroot/share/PlatformIO/boards/Artillery_Ruby.json
+++ b/buildroot/share/PlatformIO/boards/Artillery_Ruby.json
@@ -11,7 +11,7 @@
       ]
     ],
     "mcu": "stm32f401rct6",
-    "variant": "Artillery_Ruby"
+    "variant": "ARTILLERY_RUBY"
   },
   "debug": {
     "jlink_device": "STM32F401RC",


### PR DESCRIPTION
You are defining in your custom board definition (`buildroot/share/PlatformIO/boards/Artillery_Ruby.json`) that the variant name is `Artillery_Ruby`. 

https://github.com/artillery3d/sidewinder-x2-firmware/blob/fc9408316c220da701619c8479baed043a244c68/buildroot/share/PlatformIO/boards/Artillery_Ruby.json#L13-L14

Since the environment for the board uses the script to automatically copy the prepared Arduino variant folder into the framework folder through `generic_create_variant.py`,

https://github.com/artillery3d/sidewinder-x2-firmware/blob/fc9408316c220da701619c8479baed043a244c68/ini/stm32f4.ini#L410-L411

the `generic_create_variant.py` script will be looking for 

https://github.com/artillery3d/sidewinder-x2-firmware/blob/fc9408316c220da701619c8479baed043a244c68/buildroot/share/PlatformIO/scripts/generic_create_variant.py#L40-L52

The folder `buildroot/share/PlatformIO/variants/Artillery_Ruby`. 

However, this folder doesn't exist, since you named it uppercase `ARTILLERY_RUBY`

https://github.com/artillery3d/sidewinder-x2-firmware/tree/main/buildroot/share/PlatformIO/variants/ARTILLERY_RUBY

The only operating system that this works by coincidence is Windows, since its filesystem does not care about upper/lowercase. Every Linux and Mac user will be greeted with

```
platformio run -e ARTILLERY_RUBY Processing ARTILLERY_RUBY (platform: ststm32@~12.1; board: Artillery_Ruby; framework: arduino)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
AssertionError: :
  File "/home/a9/.platformio/penv/lib/python3.7/site-packages/platformio/builder/main.py", line 178:
    env.SConscript(item, exports="env")
  File "/home/a9/.platformio/packages/tool-scons/scons-local-4.2.0/SCons/Script/SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/a9/.platformio/packages/tool-scons/scons-local-4.2.0/SCons/Script/SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/a9/Downloads/sidewinder-x2-firmware-main/buildroot/share/PlatformIO/scripts/generic_create_variant.py", line 52:
    assert os.path.isdir(source_dir)
==================[FAILED] Took 0.51 seconds ==================
```

.. an error message that the target path does not exist, since you've spelled it incorrectly.

This PR fixes that by referencing the actually correct foldername.

People have noticed this build failure in https://community.platformio.org/t/newbee-needs-help-with-an-error-at-compilation-in-the-sourcecode-of-artillery-ruby-board/24145 too.