### PR TITLE
Build action to automatically build sources and create firmware zip containing HEX file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: PIO CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install platformio
+    # It is important to first install the libraries before compiling, since otherwise compilation might fail to find the just-installed libraries
+    - name: Install platformIO libraries
+      run: pio lib install
+    - name: Run PlatformIO
+      run: platformio run
+    - name: 'Upload firmware'
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware
+        path: .pio/build/ARTILLERY_RUBY/firmware.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,5 @@
 # This is a basic workflow to help you get started with Actions
-
-name: PIO CI
+name: Build Artillery Ruby firmware
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -29,12 +28,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install platformio
     # It is important to first install the libraries before compiling, since otherwise compilation might fail to find the just-installed libraries
-    - name: Update platformIO libraries
-      run: pio pkg update
+    - name: Install platformIO libraries
+      run: pio lib install
     - name: Run PlatformIO
       run: pio run
     - name: 'Upload firmware'
       uses: actions/upload-artifact@v4
       with:
         name: firmware
-        path: .pio/build/ARTILLERY_RUBY/firmware.*
+        path: .pio/build/ARTILLERY_RUBY/firmware.hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install platformio
     # It is important to first install the libraries before compiling, since otherwise compilation might fail to find the just-installed libraries
-    - name: update platformIO libraries
+    - name: Update platformIO libraries
       run: pio pkg update
     - name: Run PlatformIO
-      run: pio run -v
+      run: pio run
     - name: 'Upload firmware'
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install platformio
     # It is important to first install the libraries before compiling, since otherwise compilation might fail to find the just-installed libraries
-    - name: Install platformIO libraries
-      run: pio lib install
+    - name: update platformIO libraries
+      run: pio pkg update
     - name: Run PlatformIO
-      run: platformio run
+      run: pio run -v
     - name: 'Upload firmware'
       uses: actions/upload-artifact@v4
       with:

--- a/buildroot/share/PlatformIO/boards/Artillery_Ruby.json
+++ b/buildroot/share/PlatformIO/boards/Artillery_Ruby.json
@@ -11,7 +11,7 @@
       ]
     ],
     "mcu": "stm32f401rct6",
-    "variant": "Artillery_Ruby"
+    "variant": "ARTILLERY_RUBY"
   },
   "debug": {
     "jlink_device": "STM32F401RC",


### PR DESCRIPTION
### Description
Download to firmware bins is not working anymore. Instead of pointing to a google drive - you could point to built binaries directly from github.

this PR allows you to create an artifact "firmware.zip" containing firmware.hex - this can be used to store and offer firmware.

### Requirements
n.a.

### Benefits
Propose prebuild to your customer

### Configurations
n.a.

### Related Issues
This PR also fix a incorrect configuration in Artillery ruby json resulting in build failure on case sensitive FS (eg: Linux - used by the action).
(matching  Fix variant name for Artillery_Ruby board #3 PR)
